### PR TITLE
avoid throwing an exception

### DIFF
--- a/classes/RZLocationSimulationManager.m
+++ b/classes/RZLocationSimulationManager.m
@@ -126,7 +126,7 @@
 - (void)startSimulator {
 
     self.currentPointIndex = 0;
-    self.nextLocation = self.locationArray[ 0 ];
+    self.nextLocation = [self locationAtIndex:0];
     [self dispatchLocation];
 }
 


### PR DESCRIPTION
startSimulator was setting self.nextLocation to the wrong kind of object.

exceptional hilarity ensued when a category on CLLocation attempted.
